### PR TITLE
Add .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "ignore": [
+    "^./node_modules"
+  ]
+}


### PR DESCRIPTION
Override babel ignore defaults to transpile internal node_modules directories (closes cloverfield-tools/universal-react-boilerplate#41).