### PR TITLE
Remove orphan babelify dep. See #35.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-eslint": "^3.1.18",
     "babel-loader": "^5.1.4",
     "babel-plugin-object-assign": "^1.2.0",
-    "babelify": "^6.1.2",
     "blue-tape": "^0.1.9",
     "eslint": "^0.23.0",
     "eslint-loader": "^0.14.0",


### PR DESCRIPTION
Looks like you have a `babelify` dep orphaned by #35.

Not sure what I'm supposed to do to run the tests -- on Ubuntu / `node@0.10.32` I get the following, even on master:

```
fs.js:438
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
Error: ENOENT, no such file or directory 'cloverfield-tools/universal-react-boilerplate/config/BUILD'
    at Object.fs.openSync (fs.js:438:18)
    at Object.fs.readFileSync (fs.js:289:15)
    at Object.<anonymous> (cloverfield-tools/universal-react-boilerplate/app/test/unit/healthcheck/index.js:13:14)
    at Module._compile (module.js:456:26)
    at normalLoader (cloverfield-tools/universal-react-boilerplate/node_modules/babel-core/lib/api/register/node.js:199:5)
    at Object.require.extensions.(anonymous function) [as .js] (cloverfield-tools/universal-react-boilerplate/node_modules/babel-core/lib/api/register/node.js:216:7)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
```