### PR TITLE
[#57] Upgrade to Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,20 +1,10 @@
 {
-  "stage": 0,
-  "env": {
-    "development": {
-      "plugins": ["react-transform"],
-      "extra": {
-        "react-transform": {
-          "transforms": [{
-            "transform": "react-transform-hmr",
-            "imports": ["react"],
-            "locals": ["module"]
-          }, {
-            "transform": "react-transform-catch-errors",
-            "imports": ["react", "redbox-react"]
-          }]
-        }
-      }
-    }
-  }
+  "presets": [
+    "es2015",
+    "react"
+  ],
+  "plugins": [
+    "transform-es2015-modules-commonjs",
+    "transform-object-rest-spread"
+  ]
 }

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-./app/public/js/
+app/node_modules/public/js/

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  node:
+    version: v0.10.40
+
+
+dependencies:
+  pre:
+    - npm install -g npm@3
+
+test:
+  override:
+    - ./node_modules/.bin/eslint --debug . --format tap | ./node_modules/.bin/tap-xunit > ${CIRCLE_TEST_REPORTS}/lint.xml && test ${PIPESTATUS[0]} -eq 0
+    - NODE_PATH=source ./node_modules/.bin/babel-node source/test | ./node_modules/.bin/tap-xunit > ${CIRCLE_TEST_REPORTS}/test.xml && test ${PIPESTATUS[0]} -eq 0
+    - npm outdated --depth=0

--- a/devServer.js
+++ b/devServer.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import express from 'express';
 import webpack from 'webpack';
 import config from './webpack.config.dev';

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-react": "3.11.2",
     "express": "4.13.3",
     "rimraf": "2.4.4",
+    "tap-xunit": "^1.2.1",
     "tape": "4.2.2",
     "watch": "0.16.0",
     "webpack": "1.12.9",

--- a/package.json
+++ b/package.json
@@ -31,26 +31,28 @@
     "url": "git@github.com:ericelliott/isomorphic-express-boilerplate.git"
   },
   "devDependencies": {
-    "babel": "5.8.34",
-    "babel-core": "5.8.33",
-    "babel-eslint": "4.1.3",
-    "babel-loader": "5.4.0",
-    "babel-plugin-react-transform": "1.1.1",
+    "babel-cli": "^6.2.0",
+    "babel-core": "^6.2.1",
+    "babel-eslint": "^5.0.0-beta4",
+    "babel-loader": "^6.2.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.2.0",
+    "babel-plugin-transform-object-rest-spread": "^6.1.18",
+    "babel-preset-es2015": "^6.1.18",
+    "babel-preset-react": "^6.1.18",
     "cheerio": "0.19.0",
-    "eslint": "1.9.0",
-    "eslint-plugin-react": "3.6.3",
+    "eslint": "1.10.3",
+    "eslint-plugin-react": "3.11.2",
     "express": "4.13.3",
-    "redbox-react": "1.1.1",
-    "rimraf": "2.4.3",
-    "tape": "4.2.1",
+    "rimraf": "2.4.4",
+    "tape": "4.2.2",
     "watch": "0.16.0",
-    "webpack": "1.9.6",
-    "webpack-dev-middleware": "1.2.0",
-    "webpack-hot-middleware": "2.0.0"
+    "webpack": "1.12.9",
+    "webpack-dev-middleware": "1.4.0",
+    "webpack-hot-middleware": "2.6.0"
   },
   "dependencies": {
-    "react": "0.14.0",
-    "react-dom": "0.14.0"
+    "react": "0.14.3",
+    "react-dom": "0.14.3"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Updated all other deps too.

At the moment react-transform does not support Babel 6, so redbox-react cannot be used. When it is updated, we should put them back.

I did not use Stage0 as too experimental. `es2015` preset  + `react` have pretty much everything. Except two extra things that I added as plugins (Object rest spread and ES6 modules support).

Tests are passed, app is running well.