### PR TITLE
[#48] Set default dev host to 0.0.0.0 and allow to redefine NODE_HOST and NODE_PORT

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -6,6 +6,8 @@ import mainRoute from 'server/routes/main';
 
 const app = express();
 const compiler = webpack(config);
+const NODE_PORT = process.env.NODE_PORT || 3000;
+const NODE_HOST = process.env.NODE_HOST || '0.0.0.0';
 
 app.use(require('webpack-dev-middleware')(compiler, {
   noInfo: true,
@@ -16,11 +18,6 @@ app.use(require('webpack-hot-middleware')(compiler));
 
 app.get('/', mainRoute);
 
-app.listen(3000, 'localhost', (err) => {
-  if (err) {
-    console.log(err);
-    return;
-  }
-
-  console.log('Listening at http://localhost:3000');
-});
+app.listen(NODE_PORT, NODE_HOST, (err) => err ?
+  console.error(err) :
+  console.log(`Listening at http://${NODE_HOST}:${NODE_PORT}`));


### PR DESCRIPTION
<img width="735" alt="20151222-202720" src="https://cloud.githubusercontent.com/assets/175264/11952166/75f25e5a-a8ea-11e5-8a8e-5d1fca71639e.png">

Small change but quite helpful. Default host value `0.0.0.0` makes it available from anywhere else. Since it is dev server - that is ok.