### PR TITLE
Improvements for end-2-end tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ machine:
 dependencies:
   pre:
     - npm install -g npm@3
+    - npm set progress=false
 
 test:
   override:
@@ -14,3 +15,7 @@ test:
     - npm outdated --depth=0
     - npm run build -s
     - REPORT_DIR=${CIRCLE_TEST_REPORTS} LOG_DIR=${CIRCLE_ARTIFACTS} npm run test:e2e -s
+
+general:
+  artifacts:
+    - reports

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -1,32 +1,27 @@
 {
   "src_folders" : ["source/test/functional/browser"],
-  "output_folder" : "./reports/test-e2e",
-  "custom_commands_path" : "",
-  "custom_assertions_path" : "",
-  "page_objects_path" : "",
-  "globals_path" : "",
+  "output_folder" : "reports/test-e2e",
 
   "selenium" : {
-    "start_process" : false,
-    "server_path" : "",
-    "log_path" : "",
-    "host" : "127.0.0.1",
-    "port" : 4444,
-    "cli_args" : {
-      "webdriver.chrome.driver" : "",
-      "webdriver.ie.driver" : ""
-    }
+    "start_process" : false
+  },
+
+  "test_workers": {
+    "enabled": true,
+    "workers": 8
   },
 
   "test_settings" : {
     "default" : {
-      "launch_url" : "http://localhost",
+      "launch_url" : "http://localhost:3000",
       "selenium_port"  : 4444,
       "selenium_host"  : "localhost",
       "silent": true,
       "screenshots" : {
-        "enabled" : false,
-        "path" : ""
+        "enabled" : true,
+        "on_failure" : true,
+        "on_error" : false,
+        "path" : "reports/test-e2e"
       },
       "desiredCapabilities": {
         "browserName": "chrome",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "2.4.0",
     "eslint-plugin-react": "4.2.2",
     "estraverse-fb": "1.3.1",
-    "nightwatch-autorun": "2.1.3",
+    "nightwatch-autorun": "2.3.1",
     "react-transform-catch-errors": "1.0.2",
     "react-transform-hmr": "1.0.4",
     "redbox-react": "1.2.2",

--- a/source/test/functional/browser/smoketest.js
+++ b/source/test/functional/browser/smoketest.js
@@ -1,10 +1,9 @@
 var WAIT = 1000;
-var NODE_PORT = process.env.NODE_PORT || 3000;
 
 module.exports = {
   'Smoketest' (browser) {
     browser
-      .url(`http://localhost:${NODE_PORT}/test-data`)
+      .url(`${browser.launchUrl}/test-data`)
       .waitForElementVisible('body', WAIT)
       .assert.containsText('body', 'Books')
       .end();


### PR DESCRIPTION
1. Removed duplication of NODE_PORT and hardcoded site url in e2e tests, replaced with `launchUrl` from `nightwatch.json` config
2. Cleaned up nightwatch config a bit
3. Run e2e tests in parallel
4. Create screenshots on e2e failures (much easier to debug)
5. Added reports dir as CircleCI artifacts so it is possible to see screenshots online
