### PR TITLE
Match all incoming routes

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -15,7 +15,7 @@ app.use(require('webpack-dev-middleware')(compiler, {
 
 app.use(require('webpack-hot-middleware')(compiler));
 
-app.get('/', mainRoute);
+app.get('*', mainRoute);
 
 app.listen(3000, 'localhost', (err) => {
   if (err) {


### PR DESCRIPTION
Without the asterix, there is no ability to load other routes than the root on refresh.
For example when my URL is `/test` and I refresh, it renders `Not found.`.